### PR TITLE
Prevent removeListener calling on already disposed ChangeNotifier

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,56 +7,56 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.3"
+    version: "2.5.0"
   bloc:
     dependency: "direct main"
     description:
       name: bloc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.0.0-nullsafety.0"
+    version: "7.0.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
   builders:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.0.1"
+    version: "2.0.1"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.5"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.3"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.5"
+    version: "1.15.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -70,7 +70,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.3"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -87,35 +87,35 @@ packages:
       name: get_it
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0-nullsafety.1"
+    version: "7.1.3"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.3"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.6"
+    version: "1.3.0"
   nested:
     dependency: transitive
     description:
       name: nested
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.5-nullsafety.1"
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.3"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -127,55 +127,55 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.4"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.6"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.3"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.6"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.5"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.5"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.12.0-29.10.beta <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -21,8 +21,8 @@ environment:
   sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
-  bloc: ^7.0.0-nullsafety.0
-  get_it: 6.0.0-nullsafety.1
+  bloc: ^7.0.0-nullsafety.4
+  get_it: 7.1.3
   builders: 
     path: ../
   flutter:

--- a/lib/src/consumer.dart
+++ b/lib/src/consumer.dart
@@ -35,8 +35,8 @@ class _ConsumerState<T extends ChangeNotifier> extends State<Consumer<T>> {
 
   @override
   void dispose() {
-    super.dispose();
     _value?.removeListener(_listener);
+    super.dispose();
   }
 
   @override

--- a/lib/src/consumer.dart
+++ b/lib/src/consumer.dart
@@ -35,7 +35,7 @@ class _ConsumerState<T extends ChangeNotifier> extends State<Consumer<T>> {
 
   @override
   void dispose() {
-    _value?.removeListener(_listener);
+    //_value?.removeListener(_listener); // Don't call removeListener after object was disposed. Disposing of ChangeNotifier should be treated by the Injection framework
     super.dispose();
   }
 

--- a/lib/src/selector.dart
+++ b/lib/src/selector.dart
@@ -45,7 +45,7 @@ class _SelectorState<T extends ChangeNotifier, D>
   @override
   void dispose() {
     super.dispose();
-    _value?.removeListener(_listener);
+    //_value?.removeListener(_listener);
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: bloc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.0.0-nullsafety.2"
+    version: "7.0.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: builders
 description: Use Consumer, Select and BlocConsumer in any System Injector.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/Flutterando/builders
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
-  bloc: ^7.0.0-nullsafety.2
+  bloc: ^7.0.0-nullsafety.4
   nested: ">=1.0.0 <2.0.0"
   flutter:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: builders
 description: Use Consumer, Select and BlocConsumer in any System Injector.
-version: 2.0.1
+version: 2.0.2
 homepage: https://github.com/Flutterando/builders
 
 environment:


### PR DESCRIPTION
On current code, when the Consumer is disposed of, it tries to remove the listener from ChangeNotifier. This behavior would be OK if the object implementing the ChangeNotifier was not under an Injection framework (Modular, Getit, and so on).

When it is under Modular (our case), modular disposes of the Module and all its Binds immediately, and does not wait for the Page to be disposed of before disposing the Binded objects. This creates a situation where Modular disposes of the ChangeNotifier implemented object before Consumer is disposed of, causing Consumer to try to removeListener on a already disposed of object.

The right way to do this would be to have a mounted control variable on ChangeNotifier, just like we have on Widgets. This would allow us to check if the notifier is already disposed of, and not call removeListener. Unfortunately this is not possible, in that case, I propose we remove the removeListener, considering that builders is supposed to be used together with Injection Dependencies Frameworks like Modular, which **should** control the disposing of the notifier.